### PR TITLE
Install JAVA17 and set JAVA17 Home

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,10 +60,12 @@ RUN rm -rf /var/lib/apt/lists/* \
 RUN apt-add-repository -y ppa:openjdk-r/ppa \
   && apt-get update \
   && apt-get install -y --no-install-recommends openjdk-11-jdk \
+  && apt-get install -y --no-install-recommends openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/* \
   && update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
 
 ENV JAVA_HOME_11_X64=/usr/lib/jvm/java-11-openjdk-amd64 \
+    JAVA_HOME_17_X64=/usr/lib/jvm/java-17-openjdk-amd64 \
     JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 \
     JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 


### PR DESCRIPTION
Attempting to install JAVA 17 and set the JAVA 17 HOME whilst defaulting to JAVA 11 to avoid breaking any existing usages.
The pipelines requiring JAVA 17 can set to use the JAVA 17 home instead via https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/java-tool-installer-v0?view=azure-pipelines

Note: builds fine locally, but untested on the AKS cluster so not sure whoever reviews wants to check it first?