### PR TITLE
Install storage-preview extension in base agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,9 @@ RUN rm -rf /var/lib/apt/lists/* \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /etc/apt/sources.list.d/*
 
+# Install Azure CLI storage extension
+RUN az extension add --name storage-preview
+
 # Install Java OpenJDKs
 RUN apt-add-repository -y ppa:openjdk-r/ppa \
   && apt-get update \


### PR DESCRIPTION
Everytime the devops agent restarts the pod, we need to install the storage-preview extension for the azure cli in our builds, which can take up to 10 minutes. This happens quite often so we would like to remove the check and install step on our pipelines by having the base agent install the extension directly into the image.