### PR TITLE
Update to use sqlpackage v170 instead of v15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - > /d
   && apt-get install -y docker-ce
 
 # Install SQLPackage
-ARG SQLPACKAGE_URL=https://go.microsoft.com/fwlink/?linkid=2143497
+ARG SQLPACKAGE_URL=https://go.microsoft.com/fwlink/?linkid=2316311
 RUN mkdir /opt/sqlpackage \
     && wget -O sqlpackage-linux.zip ${SQLPACKAGE_URL} \
     && unzip sqlpackage-linux.zip -d /opt/sqlpackage \


### PR DESCRIPTION
Updating from using windows-2019 images (which is now deprecated) to windows-2022 images requires an update to the Visual Studio version when building for SQL dacpacs.
This updated version means the generated dacpac can not be handled by the older v15 sqlpackage which the current wget link downloads. This version is also significantly out of date and potentially can be a security issue?
The latest link downloading the sqlpackage v170 should be backwards compatible with older SQL versions still so this should not break anything.
It seems mostly it is SDP using sqlpackage so hopefully the impact on other teams is minimal.